### PR TITLE
fix: Mismatch between bluenotiondb env generator Output and bluenotiondb

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,10 +60,10 @@
         <input type="text" id="github_token___a"
                name="github_token___a"
                placeholder="ghp-xxxx-xxxx-xxxx"><br>
-        <!--  github_user_name -->
-        <label for="github_user_name">GitHub User Name:</label><br>
-        <input type="text" id="github_user_name"
-               name="github_user_name"
+        <!--  github_username -->
+        <label for="github_username">GitHub User Name:</label><br>
+        <input type="text" id="github_username"
+               name="github_username"
                placeholder="GitHub User Name"><br>
     </div>
     <div>
@@ -150,7 +150,7 @@
             'notion_database_id',
             'notion_api_key',
             'github_token___a',
-            'github_user_name',
+            'github_username',
         ],
         // GitHub Search
         [


### PR DESCRIPTION
I noticed that the environment variables generated by bluenotiondb env generator do not match the ones actually used by `bluenotiondb`. Specifically, the discrepancy is with the "github_user_name" variable.

The bluenotiondb env generator outputs a variable named "github_user_name", while `bluenotiondb` actually uses a variable named ["github_username"](https://github.com/azu/bluenotiondb/blob/7cc52fd39da516b16a4a229e5322b43fb5e64685/src/services/github.ts#L11-L18
). so I got the error below.


```fish
21 |     } else if (isCalendarEnv(env)) {
22 |         return CalendarType;
23 |     } else if (isRssEnv(env)) {
24 |         return RSSType;
25 |     }
26 |     throw new Error("unknown env type" + (env as { Type: "invalid" }).Type);
              ^
error: unknown env typeundefined
      at typeOfEnv (/Users/aliyome/repos/bluenotiondb/src/notion/envs.ts:26:10)
      at /Users/aliyome/repos/bluenotiondb/src/index.ts:45:20
error: script "main" exited with code 1 (SIGHUP)
```

After applying this patch, everything worked as expected.